### PR TITLE
Make DAMOV compatible with Ubuntu 20.04+ and GCC 7.0+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+*.dep
+*.deppo
+*.op
+*.so
+*.po
+.sconsign.dblite
+simulator/build/*
+
+

--- a/simulator/SConstruct
+++ b/simulator/SConstruct
@@ -54,7 +54,7 @@ def buildSim(cppFlags, dir, type, pgo=None):
     # NOTE (dsm 10 Jan 2013): Tested with Pin 2.10 thru 2.12 as well
     # NOTE: Original Pin flags included -fno-strict-aliasing, but zsim does not do type punning
     # NOTE (dsm 16 Apr 2015): Update flags code to support Pin 2.14 while retaining backwards compatibility
-    env["CPPFLAGS"] += " -g -std=c++0x -Wall -w -Wno-unknown-pragmas -fomit-frame-pointer -fno-stack-protector"
+    env["CPPFLAGS"] += " -g -std=c++0x -Wall -w -Wno-deprecated -Wno-unused-function -Wno-unknown-pragmas -Wno-catch-value -fomit-frame-pointer -fno-stack-protector"
     env["CPPFLAGS"] += " -MMD -DBIGARRAY_MULTIPLIER=1 -DUSING_XED -DTARGET_IA32E -DHOST_IA32E -fPIC -DTARGET_LINUX"
     # NOTE: (mgao Jan 2017): Pin 2.14 requires ABI version of 1002, while gcc-5 and later bumps the API version.
     # Switch to gcc-4.x by using -fabi-version=2
@@ -123,6 +123,7 @@ def buildSim(cppFlags, dir, type, pgo=None):
     env["LIBS"] = ["config++"]
 
     env["LINKFLAGS"] = ""
+    env["RPATH"] = []
 
     if useIcc:
         # icc libs

--- a/simulator/src/pin_cmd.cpp
+++ b/simulator/src/pin_cmd.cpp
@@ -55,6 +55,7 @@ PinCmd::PinCmd(Config* conf, const char* configFile, const char* outputDir, uint
     args.push_back(pinPath);
 
     //Global pin options
+    args.push_back("-ifeellucky");
     args.push_back("-follow_execv"); //instrument child processes
     args.push_back("-tool_exit_timeout"); //don't wait much of internal threads
     args.push_back("1");

--- a/simulator/src/signum.h
+++ b/simulator/src/signum.h
@@ -1,0 +1,55 @@
+/* Signal number definitions.  Linux version.
+   Copyright (C) 1995-2018 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, see
+   <http://www.gnu.org/licenses/>.  */
+
+#ifndef _BITS_SIGNUM_H
+#define _BITS_SIGNUM_H 1
+
+#ifndef _SIGNAL_H
+#error "Never include <bits/signum.h> directly; use <signal.h> instead."
+#endif
+
+#include <bits/signum-generic.h>
+
+/* Adjustments and additions to the signal number constants for
+   most Linux systems.  */
+
+#define	SIGSTKFLT	16	/* Stack fault (obsolete).  */
+#define	SIGPWR		30	/* Power failure imminent.  */
+
+#undef	SIGBUS
+#define	SIGBUS		 7
+#undef	SIGUSR1
+#define	SIGUSR1		10
+#undef	SIGUSR2
+#define	SIGUSR2		12
+#undef	SIGCHLD
+#define	SIGCHLD		17
+#undef	SIGCONT
+#define	SIGCONT		18
+#undef	SIGSTOP
+#define	SIGSTOP		19
+#undef	SIGTSTP
+#define	SIGTSTP		20
+#undef	SIGURG
+#define	SIGURG		23
+#undef	SIGPOLL
+#define	SIGPOLL		29
+#undef	SIGSYS
+#define SIGSYS		31
+
+#undef	__SIGRTMAX
+#define __SIGRTMAX	64
+
+#endif	/* <signal.h> included.  */

--- a/simulator/src/virt/virt.cpp
+++ b/simulator/src/virt/virt.cpp
@@ -74,6 +74,16 @@ void VirtInit() {
 // Dispatch methods
 void VirtSyscallEnter(THREADID tid, CONTEXT *ctxt, SYSCALL_STANDARD std, const char* patchRoot, bool isNopThread) {
     uint32_t syscall = PIN_GetSyscallNumber(ctxt, std);
+    if (syscall == SYS_arch_prctl && PIN_GetContextReg(ctxt, REG_RDI) == 0x3001) {
+        PIN_SetContextReg(ctxt, REG_INST_PTR, PIN_GetContextReg(ctxt, REG_INST_PTR) + 2);
+        PIN_SetContextReg(ctxt, REG_RAX, -1UL);
+        return;
+    }
+    if (syscall == 435/*SYS_clone3*/) {
+        PIN_SetContextReg(ctxt, REG_RAX, -ENOSYS);
+        PIN_SetContextReg(ctxt, REG_INST_PTR, PIN_GetContextReg(ctxt, REG_INST_PTR) + 2);
+        return;
+    }
     if (syscall >= MAX_SYSCALLS) {
         warn("syscall %d out of range", syscall);
         postPatchFunctions[tid] = NullPostPatch;

--- a/simulator/src/zsim.cpp
+++ b/simulator/src/zsim.cpp
@@ -28,7 +28,9 @@
 
 #include "zsim.h"
 #include <algorithm>
-//#include <bits/signum.h>
+#define _SIGNAL_H
+#include <signum.h>
+#undef _SIGNAL_H
 #include <signal.h>
 #include <dlfcn.h>
 #include <execinfo.h>


### PR DESCRIPTION
This bunch of codes mainly help DAMOV (or Zsim) compatible with Ubuntu 22.04 and GCC 9.4. Now when building DAMOV with Ubuntu 20.04+, GCC 7.0+ (I tested 7.4 and 9.4) and pin 2.14, it will encounter "Unknown sub-function for SYS_arch_prctl" problem, see https://github.com/s5z/zsim/issues/261.